### PR TITLE
Add commands for violations by author

### DIFF
--- a/pylintdb.py
+++ b/pylintdb.py
@@ -122,5 +122,23 @@ def where(condition):
         print("{gitdir}/{file}:{lineno}: {code}({slug}) {message}".format(gitdir=GIT_DIR, **row))
 
 
+@cli.command()
+def authors():
+    """List out all authors and their violation counts."""
+    sql = f"select author,count(*) as violationcount from violation group by author order by violationcount DESC"
+    for row in get_database().query(sql):
+        print(f"Author: {row['author']} - {row['violationcount']} violations")
+
+
+@cli.command()
+@click.argument("author")
+def authorviolations(author):
+    """List out violation count by a particular author."""
+    sql = f"select code, slug, count(code) as violationcount from violation where author='{author}' group by code order by violationcount DESC"
+    print(f"Violations for {author}\n")
+    for row in get_database().query(sql):
+        print(f"{row['code']}:{row['slug']} - {row['violationcount']}")
+
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
I thought it was fun to put this together: adds a few commands for listing all authors & the number of violations for each, as well as for a given author the counts by violation type.

The former is more for some fun ribbing amongst colleagues ("Hey joe you have the most Pylint violations!"), the latter is somewhat useful for finding rules a developer commonly violates (so as to inform growth areas for them to focus on).

Thanks for the tool, found it helpful & fun to play with!